### PR TITLE
Add (revised) tests for Nolan's piecewise parameter rounding

### DIFF
--- a/scipy/stats/_levy_stable_distn.py
+++ b/scipy/stats/_levy_stable_distn.py
@@ -85,22 +85,39 @@ def _pdf_single_value_cf_integrate(x, alpha, beta, **kwds):
     return (int1 + int2) / np.pi
 
 
-def _nolan_round_difficult_input(x0, alpha, beta, zeta, **kwds):
+def _nolan_round_difficult_input(x, x0, alpha, beta, zeta, xi, **kwds):
     """Round difficult input values for Nolan's method in [NO]."""
-    x_tol_near_zeta = kwds.get("piecewise_x_tol_near_zeta", 0.005)
-    alpha_tol_near_one = kwds.get("piecewise_alpha_tol_near_one", 0.005)
+    x_tol_near_zeta = kwds.get("piecewise_x_tol_near_zeta", 0.01)
+    alpha_tol_near_one = kwds.get("piecewise_alpha_tol_near_one", 0.0075)
+    alpha_one_beta_tol_near_zero = kwds.get(
+        "piecewise_alpha_one_beta_tol_near_zero", 1e-12
+    )
 
     # following Nolan's STABLE,
     #   "1. When 0 < |alpha-1| < 0.005, the program has numerical problems
     #   evaluating the pdf and cdf.  The current version of the program sets
     #   alpha=1 in these cases. This approximation is not bad in the S0
     #   parameterization."
+    # It seems we need ~0.0075 here, perhaps due to scipy's parameterization
     if np.abs(alpha - 1) < alpha_tol_near_one:
+        if alpha != 1.0:
+            # recompute quantities after alpha change
+            x += zeta  # need to shift x with scipy's parameterization
+            zeta = _nolan_zeta(1.0, beta)
+            xi = _nolan_xi(alpha, zeta)
+            x0 = x
+
         alpha = 1.0
 
     #   "2. When alpha=1 and |beta| < 0.005, the program has numerical
     #   problems.  The current version sets beta=0."
     # We seem to have addressed this through re-expression of g(theta) here
+    # That said, we need to avoid FP issues with *very* small beta
+    if alpha == 1.0 and np.abs(beta) < alpha_one_beta_tol_near_zero:
+        beta = 0.0
+
+        # recompute quantities after beta change
+        zeta = _nolan_zeta(alpha, beta)
 
     #   "8. When |x0-beta*tan(pi*alpha/2)| is small, the
     #   computations of the density and cumulative have numerical problems.
@@ -113,11 +130,11 @@ def _nolan_round_difficult_input(x0, alpha, beta, zeta, **kwds):
     #
     # We seem to have partially addressed this through re-expression of
     # g(theta) here, but it still needs to be used in some extreme cases.
-    # Perhaps tol(5) = 0.5e-2 could be reduced for our implementation.
+    # It seems we need ~1e-2 here, perhaps due to scipy's parameterization
     if np.abs(x0 - zeta) < x_tol_near_zeta * alpha ** (1 / alpha):
         x0 = zeta
 
-    return x0, alpha, beta
+    return x, x0, alpha, beta, zeta, xi
 
 
 def _nolan_g(alpha, beta, x0, xi, zeta):
@@ -193,20 +210,33 @@ def _nolan_c3(alpha):
         return 1 / np.pi
 
 
+def _nolan_zeta(alpha, beta):
+    """Special function from Nolan's method in [NO]."""
+    return -beta * np.tan(np.pi * alpha / 2.0)
+
+
+def _nolan_xi(alpha, zeta):
+    """Special function from Nolan's method in [NO]."""
+    if alpha != 1:
+        return np.arctan(-zeta) / alpha
+    else:
+        return np.pi / 2
+
+
 def _pdf_single_value_piecewise(x, alpha, beta, **kwds):
     """Calculate pdf using Nolan's methods as detailed in [NO].
     """
     quad_eps = kwds.get("quad_eps", _QUAD_EPS)
 
-    zeta = -beta * np.tan(np.pi * alpha / 2.0)
-    xi = np.arctan(-zeta) / alpha if alpha != 1 else np.pi / 2
+    zeta = _nolan_zeta(alpha, beta)
+    xi = _nolan_xi(alpha, zeta)
 
     # convert from Nolan's S_1 (aka S) to S_0 (aka Zolaterev M)
     # parameterization
     x0 = x + zeta if alpha != 1 else x
 
-    x0, alpha, beta = _nolan_round_difficult_input(
-        x0, alpha, beta, zeta, **kwds
+    x, x0, alpha, beta, zeta, xi = _nolan_round_difficult_input(
+        x, x0, alpha, beta, zeta, xi, **kwds
     )
 
     # handle Nolan's initial case logic with
@@ -322,15 +352,15 @@ def _cdf_single_value_piecewise(x, alpha, beta, **kwds):
     """
     quad_eps = kwds.get("quad_eps", _QUAD_EPS)
 
-    zeta = -beta * np.tan(np.pi * alpha / 2.0)
-    xi = np.arctan(-zeta) / alpha if alpha != 1 else np.pi / 2
+    zeta = _nolan_zeta(alpha, beta)
+    xi = _nolan_xi(alpha, zeta)
 
     # convert from Nolan's S_1 (aka S) to S_0 (aka Zolaterev M)
     # parameterization
     x0 = x + zeta if alpha != 1 else x
 
-    x0, alpha, beta = _nolan_round_difficult_input(
-        x0, alpha, beta, zeta, **kwds
+    x, x0, alpha, beta, zeta, xi = _nolan_round_difficult_input(
+        x, x0, alpha, beta, zeta, xi, **kwds
     )
 
     # handle Nolan's initial case logic
@@ -450,15 +480,19 @@ class levy_stable_gen(rv_continuous):
     to either 'piecewise', 'dni' or 'fft-simpson'.
 
     To improve performance of piecewise and direct numerical integration one
-    can specify ``levy_stable.quad_eps`` (defaults to 1.2e-14). This is used
-    as the absolute and relative quadrature tolerances for direct numerical
-    integration and the relative quadrature tolerance for the piecewise method.
-    One can also specify ``levy_stable.piecewise_x_tol_near_zeta`` (defaults to
-    0.005) for how close x is to zeta before it is considered the same as x
-    [NO]. The exact check is
-    ``abs(x0 - zeta) < piecewise_x_tol_near_zeta*alpha**(1/alpha)``. One can
-    also specify ``levy_stable.piecewise_alpha_tol_near_one`` (defaults to
-    0.005) for how close alpha is to 1 before being considered equal to 1.
+    can specify several values:
+    * ``levy_stable.quad_eps`` (defaults to 1.2e-14) is used as the absolute
+    and relative quadrature tolerances for direct numerical integration and
+    the relative quadrature tolerance for the piecewise method.
+    * ``levy_stable.piecewise_x_tol_near_zeta`` (defaults to 0.01) is how
+    close x is to zeta before it is considered the same as zeta [NO]. The exact
+    check is
+    ``abs(x0 - zeta) < piecewise_x_tol_near_zeta*alpha**(1/alpha)``.
+    * ``levy_stable.piecewise_alpha_tol_near_one`` (defaults to 0.0075) is how
+    close alpha is to 1 before being considered equal to 1.
+    * ``levy_stable.piecewise_alpha_one_beta_tol_near_zero`` (defaults to
+    1e-12) is how close beta is to 0 before being considered equal to zero.
+    This only applies in the special case where alpha = 1.
 
     To increase accuracy of FFT calculation one can specify
     ``levy_stable.pdf_fft_grid_spacing`` (defaults to 0.001) and
@@ -602,10 +636,13 @@ class levy_stable_gen(rv_continuous):
         pdf_single_value_kwds = {
             "quad_eps": getattr(self, "quad_eps", _QUAD_EPS),
             "piecewise_x_tol_near_zeta": getattr(
-                self, "piecewise_x_tol_near_zeta", 0.005
+                self, "piecewise_x_tol_near_zeta", 0.01
             ),
             "piecewise_alpha_tol_near_one": getattr(
-                self, "piecewise_alpha_tol_near_one", 0.005
+                self, "piecewise_alpha_tol_near_one", 0.0075
+            ),
+            "piecewise_alpha_one_beta_tol_near_zero": getattr(
+                self, "piecewise_alpha_one_beta_tol_near_zero", 1e-12
             )
         }
 
@@ -707,10 +744,13 @@ class levy_stable_gen(rv_continuous):
         cdf_single_value_kwds = {
             "quad_eps": getattr(self, "quad_eps", _QUAD_EPS),
             "piecewise_x_tol_near_zeta": getattr(
-                self, "piecewise_x_tol_near_zeta", 0.005
+                self, "piecewise_x_tol_near_zeta", 0.01
             ),
             "piecewise_alpha_tol_near_one": getattr(
-                self, "piecewise_alpha_tol_near_one", 0.005
+                self, "piecewise_alpha_tol_near_one", 0.0075
+            ),
+            "piecewise_alpha_one_beta_tol_near_zero": getattr(
+                self, "piecewise_alpha_one_beta_tol_near_zero", 1e-12
             )
         }
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2348,12 +2348,17 @@ class TestLevyStable(object):
             )],
 
             # piecewise generally good accuracy
-            ['piecewise', 1e-11, lambda r: (
-                (r['alpha'] > 0.2)
+            ['piecewise', 1e-11, lambda r: ~(
+                (np.abs(r['x']) < 0.0075 * r['alpha'] ** (1 / r['alpha']))
+                | (r['alpha'] <= 0.2)
             )],
             # for small alpha very slightly reduced accuracy
             ['piecewise', 5e-11, lambda r: (
                 (r['alpha'] <= 0.2)
+            )],
+            # for x close to 0 (i.e. x0 close to zeta), our rounding differs from STABLE
+            ['piecewise', 1e-4, lambda r: (
+                (np.abs(r['x']) < 0.0075 * r['alpha'] ** (1 / r['alpha']))
             )],
 
             # fft accuracy reduces as alpha decreases
@@ -2456,7 +2461,8 @@ class TestLevyStable(object):
         tests = [
             # piecewise generally good accuracy
             ['piecewise', 1e-12, lambda r: ~(
-                ((r['alpha'] == 1.) & np.isin(r['beta'], [-0.3, -0.2, -0.1])
+                (np.abs(r['x']) < 0.0075 * r['alpha'] ** (1 / r['alpha']))
+                | ((r['alpha'] == 1.) & np.isin(r['beta'], [-0.3, -0.2, -0.1])
                     & (r['pct'] == 0.01))
                 | ((r['alpha'] == 1.) & np.isin(r['beta'], [0.1, 0.2, 0.3])
                     & (r['pct'] == 0.99))
@@ -2468,6 +2474,10 @@ class TestLevyStable(object):
                     & (r['pct'] == 0.01))
                 | ((r['alpha'] == 1.) & np.isin(r['beta'], [0.1, 0.2, 0.3])
                     & (r['pct'] == 0.99))
+            )],
+            # for x close to 0 (i.e. x0 close to zeta), our rounding differs from STABLE
+            ['piecewise', 1e-2, lambda r: (
+                (np.abs(r['x']) < 0.0075 * r['alpha'] ** (1 / r['alpha']))
             )],
 
             # fft accuracy poor, very poor alpha < 1
@@ -2568,6 +2578,107 @@ class TestLevyStable(object):
                 args[0], args[1], loc=args[2], scale=args[3], moments='mvsk'
             )
             assert_almost_equal(calc_stats, exp_stats)
+
+    @pytest.mark.slow
+    def test_nolan_alpha_rounding(self):
+        # alpha close to 1 are rounded to alpha = 1
+        # this test assumes piecewise_alpha_tol_near_one is in (0.005, 0.01)
+        #   (its default is currently set to 0.0075)
+        stats.levy_stable.pdf_default_method = "piecewise"
+        stats.levy_stable.cdf_default_method = "piecewise"
+        alphas = (np.arange(0.99, 0.995, 0.001).tolist() +
+                  np.arange(1.005, 1.01, 0.001).tolist())
+        betas = np.linspace(-1, 1, 21)
+        xs = np.linspace(-1, 1, 21)
+
+        cdf = stats.levy_stable.cdf
+        pdf = stats.levy_stable.pdf
+
+        for beta in betas:
+            cdf_vals_alpha_one = cdf(xs, alpha=1.0, beta=beta)
+            pdf_vals_alpha_one = pdf(xs, alpha=1.0, beta=beta)
+            for alpha in alphas:
+                # we need to correct for the shifting
+                # mean in scipy's parameterization
+                mean_location = -beta * np.tan(alpha * np.pi / 2.0)
+                cdf_vals = cdf(xs - mean_location, alpha=alpha,
+                               beta=beta)
+                assert_allclose(cdf_vals, cdf_vals_alpha_one,
+                                0.05)  # within 5%
+
+                pdf_vals = pdf(xs - mean_location, alpha=alpha,
+                               beta=beta)
+                assert_allclose(pdf_vals, pdf_vals_alpha_one,
+                                0.05)  # within 5%
+
+    @pytest.mark.slow
+    def test_nolan_beta_rounding(self):
+        # for alpha=1, Nolan rounds |beta| < 0.005 to beta = 0
+        # we do not do this rounding, so we need to check accuracy here
+        stats.levy_stable.pdf_default_method = "piecewise"
+        stats.levy_stable.cdf_default_method = "piecewise"
+        alphas = np.arange(0.5, 2.0, 0.1)
+        betas = [10 ** (-k) for k in range(2, 16)]
+        betas += [-10 ** (-k) for k in range(2, 16)]
+        xs = np.linspace(-1, 1, 21)
+
+        cdf = stats.levy_stable.cdf
+        pdf = stats.levy_stable.pdf
+
+        for alpha in alphas:
+            cdf_vals_beta_zero = cdf(xs, alpha=alpha, beta=0.0)
+            pdf_vals_beta_zero = pdf(xs, alpha=alpha, beta=0.0)
+
+            for beta in betas:
+                # we need to correct for the shifting
+                # mean in scipy's parameterization
+                if alpha != 1:
+                    mean_location = -beta * np.tan(alpha * np.pi / 2.0)
+                else:
+                    mean_location = 0
+                cdf_vals = cdf(xs - mean_location, alpha=alpha,
+                               beta=beta)
+                assert_allclose(cdf_vals, cdf_vals_beta_zero,
+                                0.05)  # within 5%
+
+                pdf_vals = pdf(xs - mean_location, alpha=alpha,
+                               beta=beta)
+                assert_allclose(pdf_vals, pdf_vals_beta_zero,
+                                0.05)  # within 5%
+
+    @pytest.mark.slow
+    def test_nolan_x0_rounding(self):
+        # in scipy's parameterization, Nolan rounds
+        #   |x| < 0.5e-2*alpha**(1/alpha) to x=0
+        # this test assumes piecewise_x_tol_near_zeta is in (0.5e-2, 1.5e-2)
+        #   (its default is currently set to 1e-2)
+        stats.levy_stable.pdf_default_method = "piecewise"
+        stats.levy_stable.cdf_default_method = "piecewise"
+        alphas = np.arange(0.5, 2.0, 0.1)
+        betas = np.arange(-1.0, 1.0, 0.1)
+
+        cdf = stats.levy_stable.cdf
+        pdf = stats.levy_stable.pdf
+
+        for alpha in alphas:
+            offsets = np.concatenate((
+                np.arange(0.5e-2, 1.5e-2, 5e-4) * alpha ** (1 / alpha),
+                np.arange(-1.5e-2, -0.5e-2, 5e-4) * alpha ** (1 / alpha),
+            ))
+
+            for beta in betas:
+                cdf_val = cdf(0, alpha=alpha, beta=beta)
+                pdf_val = pdf(0, alpha=alpha, beta=beta)
+
+                offset_cdf_val = cdf(offsets, alpha=alpha,
+                                     beta=beta)
+                assert_allclose(cdf_val, offset_cdf_val,
+                                0.05)  # within 5%
+
+                offset_pdf_val = pdf(offsets, alpha=alpha,
+                                     beta=beta)
+                assert_allclose(pdf_val, offset_pdf_val, 0.05,
+                                atol=1e-16)  # within 5% or 1e-16
 
 
 class TestArrayArgument(object):  # test for ticket:992


### PR DESCRIPTION
Very similar to https://github.com/bsdz/scipy/pull/3, so `_nolan_round_difficult_input` was tweaked and the rounding tolerances were increased

-    x_tol_near_zeta from 0.005 -> 0.01
-    alpha_tol_near_one from 0.005 -> 0.0075
-    New tolerance: when alpha=1, round |beta| < 1e-12 to beta = 0 to avoid FP issues with extremely small beta

The tests from Nolan's PDF and CDF samples had to be tweaked for these changes to pass the tests.

Also, I added `_nolan_S0_from_S1` and `_nolan_S1_from_S0` helper functions to reduce more code repetition. These may be useful if we choose to allow user-level parameterization swapping.

Lastly, the ranges in the tests from https://github.com/bsdz/scipy/pull/3 were reduced, so they should be roughly twice as fast now.