### PR TITLE
Fix issue with returning NaN outside support in special case 

### DIFF
--- a/scipy/stats/_levy_stable_distn.py
+++ b/scipy/stats/_levy_stable_distn.py
@@ -189,6 +189,9 @@ def _pdf_single_value_piecewise_Z0(x0, alpha, beta, **kwds):
         # levy
         # since S(1/2, 1, γ, δ; <x>) == S(1/2, 1, γ, δ+γ; <x0>).
         _x = x0 + 1
+        if _x < 0:
+            return 0
+
         return 1 / np.sqrt(2 * np.pi * _x) / _x * np.exp(-1 / (2 * _x))
     elif alpha == 0.5 and beta == 0.0 and x0 != 0:
         # analytical solution [HO]
@@ -309,6 +312,9 @@ def _cdf_single_value_piecewise_Z0(x0, alpha, beta, **kwds):
         # levy
         # since S(1/2, 1, γ, δ; <x>) == S(1/2, 1, γ, δ+γ; <x0>).
         _x = x0 + 1
+        if _x < 0:
+            return 0
+
         return sc.erfc(np.sqrt(0.5 / _x))
     elif alpha == 1.0 and beta == 0.0:
         # cauchy

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3426,6 +3426,36 @@ class TestLevyStable:
                                args=(alpha, beta, loc, scale))
         assert p > 0.01
 
+    @pytest.mark.parametrize('alpha', [0.25, 0.5, 0.75])
+    def test_distribution_outside_support(self, alpha):
+        """Ensure the pdf/cdf routines do not return nan outside support.
+
+        This distribution's support becomes truncated in a few special cases:
+            support is [mu, infty) if alpha < 1 and beta = 1
+            support is (-infty, mu] if alpha < 1 and beta = -1
+        Otherwise, the support is all reals. Here, mu is zero by default.
+        """
+
+        assert 0 < alpha < 1
+
+        # check beta = 1 case
+        for x in np.linspace(-25, 0, 10):
+            assert_almost_equal(
+                stats.levy_stable.cdf(x, alpha=alpha, beta=1.0), 0.0
+            )
+            assert_almost_equal(
+                stats.levy_stable.pdf(x, alpha=alpha, beta=1.0), 0.0
+            )
+
+        # check beta = -1 case
+        for x in np.linspace(0, 25, 10):
+            assert_almost_equal(
+                stats.levy_stable.cdf(x, alpha=alpha, beta=-1.0), 1.0
+            )
+            assert_almost_equal(
+                stats.levy_stable.pdf(x, alpha=alpha, beta=-1.0), 0.0
+            )
+
 
 class TestArrayArgument:  # test for ticket:992
     def setup_method(self):


### PR DESCRIPTION
As mentioned in https://github.com/scipy/scipy/pull/9523#issuecomment-885071124 and https://github.com/scipy/scipy/pull/9523#issuecomment-885101083, the CDF/PDF routines would return NaN outside the distribution support.

It seems this was just due to an analytic shortcut in the alpha == 0.5, beta == 1.0 case. The code was directly using the CDF and PDF for the Levy distribution as noted by https://en.wikipedia.org/wiki/Stable_distribution#Other_analytic_cases, but they are not defined for x < 0.

As such, I added a check for x < 0 in the shortcut, which fixes the issue. I also added a simple test making sure the CDF/PDF correctly return 0.0 or 1.0 outside the distribution support.

Here are a few examples showing the issue is fixed
```python
>>> import scipy
>>> scipy.__version__
'1.8.0.dev0+0.31afd23'
>>> 
>>> from scipy.stats import levy_stable
>>> import sys
>>> 
>>> # CDF/PDF correctly return 0.0 or 1.0 outside support at alpha=0.5, beta=+-1.0
>>> levy_stable.cdf(-10, alpha=0.5, beta=1.0)
0.0
>>> levy_stable.cdf(10, alpha=0.5, beta=-1.0)
1.0
>>> levy_stable.pdf(-10, alpha=0.5, beta=1.0)
0.0
>>> levy_stable.pdf(10, alpha=0.5, beta=-1.0)
0.0
>>> 
>>> # Note this particular NaN issue was confined to exactly this special case
>>> levy_stable.cdf(0, alpha=0.5, beta=1.0)
0.0
>>> levy_stable.cdf(0, alpha=0.501, beta=1.0)
0.0
>>> levy_stable.cdf(0, alpha=0.5, beta=0.999)
0.00031846909417854175
>>> 
>>> levy_stable.pdf(0, alpha=0.5, beta=1.0)
0.0
>>> levy_stable.pdf(0, alpha=0.501, beta=1.0)
1.9385168214798478e-17
>>> levy_stable.pdf(0, alpha=0.5, beta=0.999)
0.0003187876693227406
```

Note that all tests pass:
```bash
$ python runtests.py -v -m full -t scipy/stats/tests/test_distributions.py::TestLevyStable
Building, see build.log...
Build OK (0:00:03.504404 elapsed)
================================================ test session starts =================================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3.9
cachedir: .pytest_cache
collected 12 items                                                                                                   

scipy/stats/tests/test_distributions.py::TestLevyStable::test_rvs PASSED                                       [  8%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_fit PASSED                                       [ 16%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_pdf_nolan_samples PASSED                         [ 25%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_cdf_nolan_samples PASSED                         [ 33%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_location_scale PASSED                            [ 41%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_pdf_alpha_equals_one_beta_non_zero PASSED        [ 50%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_stats PASSED                                     [ 58%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_rvs_alpha1[0.5] PASSED                           [ 66%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_rvs_alpha1[1] PASSED                             [ 75%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_distribution_outside_support[0.25] PASSED        [ 83%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_distribution_outside_support[0.5] PASSED         [ 91%]
scipy/stats/tests/test_distributions.py::TestLevyStable::test_distribution_outside_support[0.75] PASSED        [100%]

================================================ 12 passed in 46.46s =================================================
```