### PR TITLE
TST: Separate levy_stable tests into regular, slow, xslow

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3421,9 +3421,7 @@ class TestLevyStable:
     def test_cdf_nolan_samples(
             self, nolan_cdf_sample_data, pct_range, alpha_range, beta_range
     ):
-        """ Test cdf values against Nolan's stablec.exe output
-
-        """
+        """ Test cdf values against Nolan's stablec.exe output."""
         data = nolan_cdf_sample_data
         tests = [
             # piecewise generally good accuracy
@@ -3542,7 +3540,11 @@ class TestLevyStable:
                     verbose=False
                 )
 
-    def test_location_scale(self, nolan_loc_scale_sample_data):
+    @pytest.mark.parametrize("param", [0, 1])
+    @pytest.mark.parametrize("case", ["pdf", "cdf"])
+    def test_location_scale(
+            self, nolan_loc_scale_sample_data, param, case
+    ):
         """Tests for pdf and cdf where loc, scale are different from 0, 1
         """
         data = nolan_loc_scale_sample_data
@@ -3551,28 +3553,18 @@ class TestLevyStable:
         stats.levy_stable.cdf_default_method = "piecewise"
         stats.levy_stable.pdf_default_method = "piecewise"
 
-        for param in [0, 1]:
+        subdata = data[data["param"] == param]
+        stats.levy_stable.parameterization = f"S{param}"
 
-            subdata = data[data["param"] == param]
-            stats.levy_stable.parameterization = f"S{param}"
+        assert case in ["pdf", "cdf"]
+        function = (
+            stats.levy_stable.pdf if case == "pdf" else stats.levy_stable.cdf
+        )
 
-            v1pdf = stats.levy_stable.pdf(
-                subdata['x'],
-                subdata['alpha'],
-                subdata['beta'],
-                scale=2,
-                loc=3
-            )
-            assert_allclose(v1pdf, subdata['pdf'], 1e-5)
-
-            v1cdf = stats.levy_stable.cdf(
-                subdata['x'],
-                subdata['alpha'],
-                subdata['beta'],
-                scale=2,
-                loc=3
-            )
-            assert_allclose(v1cdf, subdata['cdf'], 1e-5)
+        v1 = function(
+            subdata['x'], subdata['alpha'], subdata['beta'], scale=2, loc=3
+        )
+        assert_allclose(v1, subdata[case], 1e-5)
 
     @pytest.mark.parametrize(
         "method,decimal_places",

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3281,7 +3281,7 @@ class TestLevyStable:
                             np.isin(np.abs(r['beta']), [-.1, .1])
                         ) |
                         # various points ok but too sparse to list
-                        (r['alpha'] >= 1.1),
+                        (r['alpha'] >= 1.1)
                     )
                 )
             ],

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3222,6 +3222,10 @@ class TestLevyStable:
             [uname.system, uname.machine, uname.processor])
 
         # fmt: off
+        # There are a number of cases which fail on some but not all platforms.
+        # These are excluded by the filters below. TODO: Rewrite tests so that
+        # the now filtered out test cases are still run but marked in pytest as
+        # expected to fail.
         tests = [
             [
                 'dni', 1e-7, lambda r: (

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3627,7 +3627,38 @@ class TestLevyStable:
         assert_almost_equal(observed, expected)
 
     @pytest.mark.parametrize('alpha', [0.25, 0.5, 0.75])
-    def test_distribution_outside_support(self, alpha):
+    @pytest.mark.parametrize(
+        'function,beta,points,expected',
+        [
+            (
+                stats.levy_stable.cdf,
+                1.0,
+                np.linspace(-25, 0, 10),
+                0.0,
+            ),
+            (
+                stats.levy_stable.pdf,
+                1.0,
+                np.linspace(-25, 0, 10),
+                0.0,
+            ),
+            (
+                stats.levy_stable.cdf,
+                -1.0,
+                np.linspace(0, 25, 10),
+                1.0,
+            ),
+            (
+                stats.levy_stable.pdf,
+                -1.0,
+                np.linspace(0, 25, 10),
+                0.0,
+            )
+        ]
+    )
+    def test_distribution_outside_support(
+            self, alpha, function, beta, points, expected
+    ):
         """Ensure the pdf/cdf routines do not return nan outside support.
 
         This distribution's support becomes truncated in a few special cases:
@@ -3635,26 +3666,11 @@ class TestLevyStable:
             support is (-infty, mu] if alpha < 1 and beta = -1
         Otherwise, the support is all reals. Here, mu is zero by default.
         """
-
         assert 0 < alpha < 1
-
-        # check beta = 1 case
-        for x in np.linspace(-25, 0, 10):
-            assert_almost_equal(
-                stats.levy_stable.cdf(x, alpha=alpha, beta=1.0), 0.0
-            )
-            assert_almost_equal(
-                stats.levy_stable.pdf(x, alpha=alpha, beta=1.0), 0.0
-            )
-
-        # check beta = -1 case
-        for x in np.linspace(0, 25, 10):
-            assert_almost_equal(
-                stats.levy_stable.cdf(x, alpha=alpha, beta=-1.0), 1.0
-            )
-            assert_almost_equal(
-                stats.levy_stable.pdf(x, alpha=alpha, beta=-1.0), 0.0
-            )
+        assert_almost_equal(
+            function(points, alpha=alpha, beta=beta),
+            np.full(len(points), expected)
+        )
 
 
 class TestArrayArgument:  # test for ticket:992

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3199,8 +3199,6 @@ class TestLevyStable:
     ):
         """Test pdf values against Nolan's stablec.exe output"""
         data = nolan_pdf_sample_data
-        # support numpy 1.8.2 for travis
-        npisin = np.isin if hasattr(np, "isin") else np.in1d
 
         # some tests break on linux 32 bit
         uname = platform.uname()
@@ -3210,78 +3208,130 @@ class TestLevyStable:
 
         # fmt: off
         tests = [
-            # TODO: reduce range of pct to speed up computation as
-            # numerical integration slow, eg [.01, .05, .5, .95, .99]
-            ['dni', 1e-7, lambda r: (
-                npisin(r['pct'], pct_range) &
-                npisin(r['alpha'], alpha_range) &
-                npisin(r['beta'], beta_range) &
-                ~(
-                    ((r['beta'] == 0) & (r['pct'] == 0.5))
-                    | ((r['beta'] >= 0.9) & (r['alpha'] >= 1.6)
-                       & (r['pct'] == 0.5))
-                    | ((r['alpha'] <= 0.4) & npisin(r['pct'], [.01, .99]))
-                    | ((r['alpha'] <= 0.3) & npisin(r['pct'], [.05, .95]))
-                    | ((r['alpha'] <= 0.2) & npisin(r['pct'], [.1, .9]))
-                    | ((r['alpha'] == 0.1) & npisin(r['pct'], [.25, .75])
-                       & npisin(np.abs(r['beta']), [.5, .6, .7]))
-                    | ((r['alpha'] == 0.1) & npisin(r['pct'], [.5])
-                       & npisin(np.abs(r['beta']), [.1]))
-                    | ((r['alpha'] == 0.1) & npisin(r['pct'], [.35, .65])
-                       & npisin(np.abs(r['beta']), [-.4, -.3, .3, .4, .5]))
-                    | ((r['alpha'] == 0.2) & (r['beta'] == 0.5)
-                       & (r['pct'] == 0.25))
-                    | ((r['alpha'] == 0.2) & (r['beta'] == -0.3)
-                       & (r['pct'] == 0.65))
-                    | ((r['alpha'] == 0.2) & (r['beta'] == 0.3)
-                       & (r['pct'] == 0.35))
-                    | ((r['alpha'] == 1.) & npisin(r['pct'], [.5])
-                       & npisin(np.abs(r['beta']), [.1, .2, .3, .4]))
-                    | ((r['alpha'] == 1.) & npisin(r['pct'], [.35, .65])
-                       & npisin(np.abs(r['beta']), [.8, .9, 1.]))
-                    | ((r['alpha'] == 1.) & npisin(r['pct'], [.01, .99])
-                       & npisin(np.abs(r['beta']), [-.1, .1]))
-                    # various points ok but too sparse to list
-                    | ((r['alpha'] >= 1.1))
+            [
+                'dni', 1e-7, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    ~(
+                        (
+                            (r['beta'] == 0) &
+                            (r['pct'] == 0.5)
+                        ) |
+                        (
+                            (r['beta'] >= 0.9) &
+                            (r['alpha'] >= 1.6) &
+                            (r['pct'] == 0.5)
+                        ) |
+                        (
+                            (r['alpha'] <= 0.4) &
+                            np.isin(r['pct'], [.01, .99])
+                        ) |
+                        (
+                            (r['alpha'] <= 0.3) &
+                            np.isin(r['pct'], [.05, .95])
+                        ) |
+                        (
+                            (r['alpha'] <= 0.2) &
+                            np.isin(r['pct'], [.1, .9])
+                        ) | 
+                        (
+                            (r['alpha'] == 0.1) &
+                            np.isin(r['pct'], [.25, .75]) &
+                            np.isin(np.abs(r['beta']), [.5, .6, .7])
+                        ) |
+                        (
+                            (r['alpha'] == 0.1) &
+                            np.isin(r['pct'], [.5]) &
+                            np.isin(np.abs(r['beta']), [.1])
+                        ) |
+                        (
+                            (r['alpha'] == 0.1) &
+                            np.isin(r['pct'], [.35, .65]) &
+                            np.isin(np.abs(r['beta']), [-.4, -.3, .3, .4, .5])
+                        ) |
+                        (
+                            (r['alpha'] == 0.2) &
+                            (r['beta'] == 0.5) &
+                            (r['pct'] == 0.25)
+                        ) |
+                        (
+                            (r['alpha'] == 0.2) &
+                            (r['beta'] == -0.3) &
+                            (r['pct'] == 0.65)
+                        ) |
+                        (
+                            (r['alpha'] == 0.2) &
+                            (r['beta'] == 0.3) &
+                            (r['pct'] == 0.35)
+                        ) |
+                        (
+                            (r['alpha'] == 1.) &
+                            np.isin(r['pct'], [.5]) &
+                            np.isin(np.abs(r['beta']), [.1, .2, .3, .4])
+                        ) |
+                        (
+                            (r['alpha'] == 1.) &
+                            np.isin(r['pct'], [.35, .65]) &
+                            np.isin(np.abs(r['beta']), [.8, .9, 1.])
+                        ) |
+                        (
+                            (r['alpha'] == 1.) &
+                            np.isin(r['pct'], [.01, .99]) &
+                            np.isin(np.abs(r['beta']), [-.1, .1])
+                        ) |
+                        # various points ok but too sparse to list
+                        (r['alpha'] >= 1.1),
+                    )
                 )
-            )],
+            ],
             # piecewise generally good accuracy
-            ['piecewise', 1e-11, lambda r: (
-                npisin(r['pct'], pct_range) &
-                npisin(r['alpha'], alpha_range) &
-                npisin(r['beta'], beta_range) &
-                (r['alpha'] > 0.2) & (r['alpha'] != 1.)
-            )],
+            [
+                'piecewise', 1e-11, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    (r['alpha'] > 0.2) &
+                    (r['alpha'] != 1.)
+                )
+            ],
             # for alpha = 1. for linux 32 bit optimize.bisect
             # has some issues for .01 and .99 percentile
-            ['piecewise', 1e-11, lambda r: (
-                (r['alpha'] == 1.) & (not is_linux_32) &
-                npisin(r['pct'], pct_range) &
-                (1.0 in alpha_range) &
-                npisin(r['beta'], beta_range)
-            )],
-            # for small alpha very slightly reduced accuracy
-            ['piecewise', 5e-11, lambda r: (
-                npisin(r['pct'], pct_range) &
-                npisin(r['alpha'], alpha_range) &
-                npisin(r['beta'], beta_range) &
-                (r['alpha'] <= 0.2)
-            )],
-            # fft accuracy reduces as alpha decreases
-            ['fft-simpson', 1e-5, lambda r: (
-                (r['alpha'] >= 1.9) &
-                npisin(r['pct'], pct_range) &
-                npisin(r['alpha'], alpha_range) &
-                npisin(r['beta'], beta_range)
-            ),
+            [
+                'piecewise', 1e-11, lambda r: (
+                    (r['alpha'] == 1.) &
+                    (not is_linux_32) &
+                    np.isin(r['pct'], pct_range) &
+                    (1. in alpha_range) &
+                    np.isin(r['beta'], beta_range)
+                )
             ],
-            ['fft-simpson', 1e-6, lambda r: (
-                npisin(r['pct'], pct_range) &
-                npisin(r['alpha'], alpha_range) &
-                npisin(r['beta'], beta_range) &
-                (r['alpha'] > 1) &
-                (r['alpha'] < 1.9)
-            )
+            # for small alpha very slightly reduced accuracy
+            [
+                'piecewise', 5e-11, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    (r['alpha'] <= 0.2)
+                )
+            ],
+            # fft accuracy reduces as alpha decreases
+            [
+                'fft-simpson', 1e-5, lambda r: (
+                    (r['alpha'] >= 1.9) &
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range)
+                ),
+            ],
+            [
+                'fft-simpson', 1e-6, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    (r['alpha'] > 1) &
+                    (r['alpha'] < 1.9)
+                )
             ],
             # fft relative errors for alpha < 1, will raise if enabled
             # ['fft-simpson', 1e-4, lambda r: r['alpha'] == 0.9],
@@ -3362,56 +3412,80 @@ class TestLevyStable:
         data = nolan_cdf_sample_data
         tests = [
             # piecewise generally good accuracy
-            ['piecewise', 1e-12, lambda r: (
-                np.isin(r['pct'], pct_range) &
-                np.isin(r['alpha'], alpha_range) &
-                np.isin(r['beta'], beta_range) &
-                ~(
-                    ((r['alpha'] == 1.) & np.isin(r['beta'], [-0.3, -0.2, -0.1])
-                     & (r['pct'] == 0.01))
-                    | ((r['alpha'] == 1.) & np.isin(r['beta'], [0.1, 0.2, 0.3])
-                       & (r['pct'] == 0.99))
+            [
+                'piecewise', 1e-12, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    ~(
+                        (
+                            (r['alpha'] == 1.) &
+                            np.isin(r['beta'], [-0.3, -0.2, -0.1]) &
+                            (r['pct'] == 0.01)
+                        ) |
+                        (
+                            (r['alpha'] == 1.) &
+                            np.isin(r['beta'], [0.1, 0.2, 0.3]) &
+                            (r['pct'] == 0.99)
+                        )
+                    )
                 )
-            )],
+            ],
             # for some points with alpha=1, Nolan's STABLE clearly
             # loses accuracy
-            ['piecewise', 5e-2, lambda r: (
-                np.isin(r['pct'], pct_range) &
-                np.isin(r['alpha'], alpha_range) &
-                np.isin(r['beta'], beta_range) &
-                ((r['alpha'] == 1.) & np.isin(r['beta'], [-0.3, -0.2, -0.1])
-                    & (r['pct'] == 0.01))
-                | ((r['alpha'] == 1.) & np.isin(r['beta'], [0.1, 0.2, 0.3])
-                    & (r['pct'] == 0.99))
-            )],
+            [
+                'piecewise', 5e-2, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    (
+                        (r['alpha'] == 1.) &
+                        np.isin(r['beta'], [-0.3, -0.2, -0.1]) &
+                        (r['pct'] == 0.01)
+                    ) |
+                    (
+                        (r['alpha'] == 1.) &
+                        np.isin(r['beta'], [0.1, 0.2, 0.3]) &
+                        (r['pct'] == 0.99)
+                    )
+                )
+            ],
             # fft accuracy poor, very poor alpha < 1
-            ['fft-simpson', 1e-5, lambda r: (
-                np.isin(r['pct'], pct_range) &
-                np.isin(r['alpha'], alpha_range) &
-                np.isin(r['beta'], beta_range) &
-                (r['alpha'] > 1.7)
-            )],
-            ['fft-simpson', 1e-4, lambda r: (
-                np.isin(r['pct'], pct_range) &
-                np.isin(r['alpha'], alpha_range) &
-                np.isin(r['beta'], beta_range) &
-                (r['alpha'] > 1.5) &
-                (r['alpha'] <= 1.7)
-            )],
-            ['fft-simpson', 1e-3, lambda r: (
-                np.isin(r['pct'], pct_range) &
-                np.isin(r['alpha'], alpha_range) &
-                np.isin(r['beta'], beta_range) &
-                (r['alpha'] > 1.3) &
-                (r['alpha'] <= 1.5)
-            )],
-            ['fft-simpson', 1e-2, lambda r: (
-                np.isin(r['pct'], pct_range) &
-                np.isin(r['alpha'], alpha_range) &
-                np.isin(r['beta'], beta_range) &
-                (r['alpha'] > 1.0) &
-                (r['alpha'] <= 1.3)
-            )],
+            [
+                'fft-simpson', 1e-5, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    (r['alpha'] > 1.7)
+                )
+            ],
+            [
+                'fft-simpson', 1e-4, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    (r['alpha'] > 1.5) &
+                    (r['alpha'] <= 1.7)
+                )
+            ],
+            [
+                'fft-simpson', 1e-3, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    (r['alpha'] > 1.3) &
+                    (r['alpha'] <= 1.5)
+                )
+            ],
+            [
+                'fft-simpson', 1e-2, lambda r: (
+                    np.isin(r['pct'], pct_range) &
+                    np.isin(r['alpha'], alpha_range) &
+                    np.isin(r['beta'], beta_range) &
+                    (r['alpha'] > 1.0) &
+                    (r['alpha'] <= 1.3)
+                )
+            ],
         ]
         for ix, (default_method, rtol,
                  filter_func) in enumerate(tests):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3107,6 +3107,21 @@ class TestLevyStable:
         data = np.core.records.fromarrays(data.T, names='x,p,alpha,beta,pct')
         return data
 
+    @pytest.fixture
+    def nolan_loc_scale_sample_data(self):
+        """Sample data where loc, scale are different from 0, 1
+
+        Data extracted in similar way to pdf/cdf above using
+        Nolan's stablec but set to an arbitrary location scale of
+        (2, 3) for various important parameters alpha, beta and for
+        parameterisations S0 and S1.
+        """
+        data = np.load(
+            Path(__file__).parent /
+            'data/levy_stable/stable-loc-scale-sample-data.npy'
+        )
+        return data
+
     @pytest.mark.parametrize(
         "sample_size", [
             pytest.param(50), pytest.param(1500, marks=pytest.mark.slow)
@@ -3527,17 +3542,10 @@ class TestLevyStable:
                     verbose=False
                 )
 
-    def test_location_scale(self):
-        """Data extracted in similar way to pdf/cdf above using
-        Nolan's stablec but set to an arbitrary location scale of
-        (2, 3) for various important parameters alpha, beta and for
-        parameterisations S0 and S1.
+    def test_location_scale(self, nolan_loc_scale_sample_data):
+        """Tests for pdf and cdf where loc, scale are different from 0, 1
         """
-        data = np.load(
-            Path(__file__).parent /
-            'data/levy_stable/stable-loc-scale-sample-data.npy'
-        )
-
+        data = nolan_loc_scale_sample_data
         # We only test against piecewise as location/scale transforms
         # are same for other methods.
         stats.levy_stable.cdf_default_method = "piecewise"
@@ -3615,7 +3623,6 @@ class TestLevyStable:
                 args[0], args[1], loc=args[2], scale=args[3], moments='mvsk'
             )
             assert_almost_equal(calc_stats, exp_stats)
-
 
     @pytest.mark.parametrize('alpha', [0.25, 0.5, 0.75])
     def test_distribution_outside_support(self, alpha):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3574,7 +3574,14 @@ class TestLevyStable:
             )
             assert_allclose(v1cdf, subdata['cdf'], 1e-5)
 
-    def test_pdf_alpha_equals_one_beta_non_zero(self):
+    @pytest.mark.parametrize(
+        "method,decimal_places",
+        [
+            ['dni', 4],
+            ['piecewise', 4],
+        ]
+    )
+    def test_pdf_alpha_equals_one_beta_non_zero(self, method, decimal_places):
         """ sample points extracted from Tables and Graphs of Stable
         Probability Density Functions - Donald R Holt - 1973 - p 187.
         """
@@ -3594,24 +3601,17 @@ class TestLevyStable:
                 .25, .5, 1
             ]
         )
-
-        tests = [
-            ['dni', 4],
-            ['piecewise', 4],
-        ]
-
         with np.errstate(all='ignore'), suppress_warnings() as sup:
             sup.filter(
                 category=RuntimeWarning,
                 message="Density calculation unstable.*"
             )
-            for default_method, decimal_places in tests:
-                stats.levy_stable.pdf_default_method = default_method
-                #stats.levy_stable.fft_grid_spacing = 0.0001
-                pdf = stats.levy_stable.pdf(xs, 1, betas, scale=1, loc=0)
-                assert_almost_equal(
-                    pdf, density, decimal_places, default_method
-                )
+            stats.levy_stable.pdf_default_method = method
+            #stats.levy_stable.fft_grid_spacing = 0.0001
+            pdf = stats.levy_stable.pdf(xs, 1, betas, scale=1, loc=0)
+            assert_almost_equal(
+                pdf, density, decimal_places, method
+            )
 
     @pytest.mark.parametrize(
         "params,expected",

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9,7 +9,6 @@ import platform
 from pathlib import Path
 import os
 import json
-import numpy as np
 
 from numpy.testing import (assert_equal, assert_array_equal,
                            assert_almost_equal, assert_array_almost_equal,

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3613,16 +3613,18 @@ class TestLevyStable:
                     pdf, density, decimal_places, default_method
                 )
 
-    def test_stats(self):
-        param_sets = [
+    @pytest.mark.parametrize(
+        "params,expected",
+        [
             [(1.48, -.22, 0, 1), (0, np.inf, np.NaN, np.NaN)],
             [(2, .9, 10, 1.5), (10, 4.5, 0, 0)]
         ]
-        for args, exp_stats in param_sets:
-            calc_stats = stats.levy_stable.stats(
-                args[0], args[1], loc=args[2], scale=args[3], moments='mvsk'
-            )
-            assert_almost_equal(calc_stats, exp_stats)
+    )
+    def test_stats(self, params, expected):
+        observed = stats.levy_stable.stats(
+            params[0], params[1], loc=params[2], scale=params[3], moments='mvsk'
+        )
+        assert_almost_equal(observed, expected)
 
     @pytest.mark.parametrize('alpha', [0.25, 0.5, 0.75])
     def test_distribution_outside_support(self, alpha):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
This PR updates the tests in TestLevyStable so that there are regular, slow, and xslow test cases. The xslow tests contain all of the currently existing test cases. The slow tests contain a smaller subset and the regular tests a smaller subset still. I've tried to make it so the tests run in reasonable time frames for their type.
(i.e. regular tests in under one second, slow tests in under 10 seconds.)

This was done in such a way to minimize changes to the structure of the existing tests. `pytest.mark.parametrize` has been used to streamline tests where-ever it is applicable.

There are places in the tests where filters are used to exclude test cases that fail on some platforms. Ideally
the tests could be structured so that these cases are marked with `pytest.mark.xfail` so that they will still run. This would make life easier for anyone trying to fix these cases. I tried to implement such a thing but gave up when I saw that it would likely require significant changes to the structure of the tests. I don't have spare time to make such changes so instead chose a close to minimal set of changes to accomplish the desired objectives.

#### Additional information
<!--Any additional information you think is important.-->
I've also merged master into my feature branch. Doing so was a requirement to get scipy to build. This has created a very messy diff. Sorry for that. If I had more time, I could have done things in a better way to get a cleaner diff, but I only have a few spare minutes here and there to work on this. Fortunately, I've only worked on `scipy.stats.tests.test_distributions` so it should be reasonable to look at the diff only for that file to see the changes I've made.

Edit: I did an interactive rebase to undo merging in master. The diff is much cleaner now. I just had to delete the following files to get things to build correctly
```
scipy/_lib/unuran/
scipy/sparse/linalg/_propack/
scipy/stats/_hypotests_pythran.cpp
scipy/stats/_unuran/
```

these were added in future history and had ended up as untracked files on my local stable-improvements branch.