### PR TITLE
MAINT: Wrapping some things up

### DIFF
--- a/scipy/stats/_levy_stable_distn.py
+++ b/scipy/stats/_levy_stable_distn.py
@@ -187,7 +187,8 @@ def _pdf_single_value_piecewise_Z0(x0, alpha, beta, **kwds):
         return _norm_pdf(x0 / np.sqrt(2)) / np.sqrt(2)
     elif alpha == 0.5 and beta == 1.0:
         # levy
-        # since S(1/2, 1, γ, δ; <x>) == S(1/2, 1, γ, δ+γ; <x0>).
+        # since S(1/2, 1, gamma, delta; <x>) ==
+        # S(1/2, 1, gamma, gamma + delta; <x0>).
         _x = x0 + 1
         if _x < 0:
             return 0
@@ -310,7 +311,8 @@ def _cdf_single_value_piecewise_Z0(x0, alpha, beta, **kwds):
         return _norm_cdf(x0 / np.sqrt(2))
     elif alpha == 0.5 and beta == 1.0:
         # levy
-        # since S(1/2, 1, γ, δ; <x>) == S(1/2, 1, γ, δ+γ; <x0>).
+        # since S(1/2, 1, gamma, delta; <x>) ==
+        # S(1/2, 1, gamma, gamma + delta; <x0>).
         _x = x0 + 1
         if _x < 0:
             return 0

--- a/scipy/stats/_levy_stable_distn.py
+++ b/scipy/stats/_levy_stable_distn.py
@@ -728,7 +728,9 @@ class levy_stable_gen(rv_continuous):
 
     Any non-missing value for the attribute
     ``levy_stable.pdf_fft_min_points_threshold`` will set
-    ``levy_stable.pdf_default_method`` to 'fft-simpson'.
+    ``levy_stable.pdf_default_method`` to 'fft-simpson' if a valid
+    default method is not otherwise set.
+
 
 
     .. warning::

--- a/scipy/stats/_levy_stable_distn.py
+++ b/scipy/stats/_levy_stable_distn.py
@@ -672,22 +672,27 @@ class levy_stable_gen(rv_continuous):
     where :math:`-\infty < t < \infty`. This integral does not have a known
     closed form.
 
-    For evaluation of pdf we use either Nolan's piecewise approach using
-    Zolotarev :math:`M` parameterization with integration, direct numerical
-    integration of standard parameterization of characteristic function or FFT
-    of characteristic function.
+    Evaluation of the pdf uses Nolan's piecewise integration approach with the
+    Zolotarev :math:`M` parameterization by default. There is also the option
+    to use direct numerical integration of the standard parameterization of the
+    characteristic function or to evaluate by taking the FFT of the
+    characteristic function.
 
-    Switch parameterizations by setting ``levy_stable.parameterization``
-    to either 'S0' or 'S1'. The default is 'S1'.
+    The default method can changed by setting the class variable
+    ``levy_stable.pdf_default_method`` to one of 'piecewise' for Nolan's
+    approach, 'dni' for direct numerical integration, or 'fft-simpson' for the
+    FFT based approach. For the sake of backwards compatibility, the methods
+    'best' and 'zolotarev' are equivalent to 'piecewise' and the method
+    'quadrature' is equivalent to 'dni'.
 
-    The default method is 'piecewise' which uses Nolan's piecewise method. The
-    default method can be changed by setting ``levy_stable.pdf_default_method``
-    to either 'piecewise', 'dni' or 'fft-simpson'.
+    The parameterization can be changed  by setting the class variable
+    ``levy_stable.parameterization`` to either 'S0' or 'S1'.
+    The default is 'S1'.
 
     To improve performance of piecewise and direct numerical integration one
     can specify ``levy_stable.quad_eps`` (defaults to 1.2e-14). This is used
-    as the absolute and relative quadrature tolerances for direct numerical
-    integration and the relative quadrature tolerance for the piecewise method.
+    as both the absolute and relative quadrature tolerance for direct numerical
+    integration and as the relative quadrature tolerance for the piecewise method.
     One can also specify ``levy_stable.piecewise_x_tol_near_zeta`` (defaults to
     0.005) for how close x is to zeta before it is considered the same as x
     [NO]. The exact check is
@@ -702,17 +707,18 @@ class levy_stable_gen(rv_continuous):
 
     Further control over FFT calculation is available by setting
     ``pdf_fft_interpolation_degree`` (defaults to 3) for spline order and
-    ``pdf_fft_interpolation_level`` for determine number of points for
-    Newton-Cote formula when approximating the characteristic function
+    ``pdf_fft_interpolation_level`` for determining the number of points to use
+    in the Newton-Cotes formula when approximating the characteristic function
     (considered experimental).
 
-    For evaluation of cdf we use Nolan's piecewise approach using Zolatarev
-    :math:`S_0` parameterization with integration or integral of the pdf FFT
-    interpolated spline. The settings affecting FFT calculation are the same as
-    for pdf calculation. The default cdf method can be changed by setting
-    ``levy_stable.cdf_default_method`` to either 'piecewise' or 'fft-simpson'.
-    For cdf calculations the Zolatarev method is superior in accuracy, so FFT
-    is disabled by default.
+    Evaluation of the cdf uses Nolan's piecewise integration approach with the
+    Zolatarev :math:`S_0` parameterization by default. There is also the option
+    to evaluate through integration of an interpolated spline of the pdf
+    calculated by means of the FFT method. The settings affecting FFT
+    calculation are the same as for pdf calculation. The default cdf method can
+    be changed by setting ``levy_stable.cdf_default_method`` to either
+    'piecewise' or 'fft-simpson'.  For cdf calculations the Zolatarev method is
+    superior in accuracy, so FFT is disabled by default.
 
     Fitting estimate uses quantile estimation method in [MC]. MLE estimation of
     parameters in fit method uses this quantile estimate initially. Note that
@@ -724,8 +730,6 @@ class levy_stable_gen(rv_continuous):
     ``levy_stable.pdf_fft_min_points_threshold`` will set
     ``levy_stable.pdf_default_method`` to 'fft-simpson'.
 
-    The pdf methods 'best' and 'zolotarev' are equivalent to 'piecewise'. The
-    pdf method 'quadrature' is equivalent to 'dni'.
 
     .. warning::
 
@@ -764,11 +768,6 @@ class levy_stable_gen(rv_continuous):
     pdf_fft_n_points_two_power = None
     pdf_fft_interpolation_level = 3
     pdf_fft_interpolation_degree = 3
-    cdf_fft_min_points_threshold = None
-    cdf_fft_grid_spacing = 0.001
-    cdf_fft_n_points_two_power = None
-    cdf_fft_interpolation_level = 3
-    cdf_fft_interpolation_degree = 3
 
     def _argcheck(self, alpha, beta):
         return (alpha > 0) & (alpha <= 2) & (beta <= 1) & (beta >= -1)
@@ -1016,10 +1015,10 @@ class levy_stable_gen(rv_continuous):
             "piecewise_alpha_tol_near_one": self.piecewise_alpha_tol_near_one,
         }
 
-        fft_grid_spacing = self.cdf_fft_grid_spacing
-        fft_n_points_two_power = self.cdf_fft_n_points_two_power
-        fft_interpolation_level = self.cdf_fft_interpolation_level
-        fft_interpolation_degree = self.cdf_fft_interpolation_degree
+        fft_grid_spacing = self.pdf_fft_grid_spacing
+        fft_n_points_two_power = self.pdf_fft_n_points_two_power
+        fft_interpolation_level = self.pdf_fft_interpolation_level
+        fft_interpolation_degree = self.pdf_fft_interpolation_degree
 
         # group data in unique arrays of alpha, beta pairs
         uniq_param_pairs = np.unique(data_in[:, 1:], axis=0)

--- a/scipy/stats/_levy_stable_distn.py
+++ b/scipy/stats/_levy_stable_distn.py
@@ -20,7 +20,8 @@ from ._levy_stable.levyst import Nolan
 # some being advantageous for numerical considerations and others
 # useful due to their location/scale awareness.
 #
-# Here we follow [NO] convention.
+# Here we follow [NO] convention (see the references in the docstring
+# for levy_stable_gen below).
 #
 # S0 / Z0 / x0 (aka Zoleterav's M)
 # S1 / Z1 / x1
@@ -469,7 +470,9 @@ def _rvs_Z1(alpha, beta, size=None, random_state=None):
 def _fitstart_S0(data):
     alpha, beta, delta1, gamma = _fitstart_S1(data)
 
-    # TODO: is this correct?
+    # Formulas for mapping parameters in S1 parameterization to
+    # those in S0 parameterization can be found in [NO]. Note that
+    # only delta changes.
     if alpha != 1:
         delta0 = delta1 + beta * gamma * np.tan(np.pi * alpha / 2.0)
     else:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3207,7 +3207,7 @@ class TestLevyStable:
         """Test that fit agrees with rvs for each parametrization."""
         stats.levy_stable.parametrization = parametrization
         data = stats.levy_stable.rvs(
-            alpha, beta, loc=delta, scale=gamma, size=10000
+            alpha, beta, loc=delta, scale=gamma, size=10000, random_state=1234
         )
         fit = stats.levy_stable._fitstart(data)
         alpha_obs_S0, beta_obs_S0, delta_obs_S0, gamma_obs_S0 = fit

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3192,7 +3192,7 @@ class TestLevyStable:
         assert_almost_equal(scale2, .02503, 4)
         assert_almost_equal(loc2, .03354, 4)
 
-    @pytest.mark.xfail(reason="Undetermined bug")
+    @pytest.mark.xfail(reason="Bug. Possibly fixed by #14476.")
     @pytest.mark.parametrize(
         "alpha,beta,delta,gamma",
         [

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3192,6 +3192,30 @@ class TestLevyStable:
         assert_almost_equal(scale2, .02503, 4)
         assert_almost_equal(loc2, .03354, 4)
 
+    @pytest.mark.xfail(reason="Undetermined bug")
+    @pytest.mark.parametrize(
+        "alpha,beta,delta,gamma",
+        [
+            (1.5, 0.4, 2, 3),
+            (1.0, 0.4, 2, 3),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "parametrization", ["S0", "S1"]
+    )
+    def test_fit_rvs(self, alpha, beta, delta, gamma, parametrization):
+        """Test that fit agrees with rvs for each parametrization."""
+        stats.levy_stable.parametrization = parametrization
+        data = stats.levy_stable.rvs(
+            alpha, beta, loc=delta, scale=gamma, size=10000
+        )
+        fit = stats.levy_stable._fitstart(data)
+        alpha_obs_S0, beta_obs_S0, delta_obs_S0, gamma_obs_S0 = fit
+        assert_allclose(
+            [alpha, beta, delta, gamma],
+            [alpha_obs_S0, beta_obs_S0, delta_obs_S0, gamma_obs_S0]
+        )
+
     @pytest.mark.parametrize(
         "pct_range,alpha_range,beta_range", [
             pytest.param(

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3214,6 +3214,7 @@ class TestLevyStable:
         assert_allclose(
             [alpha, beta, delta, gamma],
             [alpha_obs, beta_obs, delta_obs, gamma_obs],
+            rtol=0.01,
         )
 
     @pytest.mark.parametrize(

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3210,10 +3210,10 @@ class TestLevyStable:
             alpha, beta, loc=delta, scale=gamma, size=10000, random_state=1234
         )
         fit = stats.levy_stable._fitstart(data)
-        alpha_obs_S0, beta_obs_S0, delta_obs_S0, gamma_obs_S0 = fit
+        alpha_obs, beta_obs, delta_obs, gamma_obs = fit
         assert_allclose(
             [alpha, beta, delta, gamma],
-            [alpha_obs_S0, beta_obs_S0, delta_obs_S0, gamma_obs_S0]
+            [alpha_obs, beta_obs, delta_obs, gamma_obs],
         )
 
     @pytest.mark.parametrize(

--- a/tools/unicode-check.py
+++ b/tools/unicode-check.py
@@ -10,13 +10,8 @@ import argparse
 # The set of Unicode code points greater than 127 that we
 # allow in the source code.
 box_drawing_chars = set(chr(cp) for cp in range(0x2500, 0x2580))
-greek_letters = set(chr(cp) for cp in chain(
-    range(0x03b1, 0x3c2), range(0x3c3, 0x03c9 + 1),  # small
-    range(0x0391, 0x03a2), range(0x03a3, 0x03a9 + 1))  # large
-)
 allowed = (set(['®', 'é', 'ê', 'ó', 'ö', 'ü', '∫', '≠', '≥']) |
-           box_drawing_chars |
-           greek_letters)
+           box_drawing_chars)
 
 
 def unicode_check(showall=False):


### PR DESCRIPTION
This PR wraps up a number of things.

1. It clears up an inconsistency in interpolation methods used for the FFT simpson method between the PDF calculation and the CDF calculation. Previously the variable `pdf_interpolation_kind` was declared but unused in the CDF calculation. My understanding of what was happening is that the PDF calculation used `scipy.interpolate.interp1d` but the CDF calculation used `scipy.interpolate.InterpolatedUnivariateSpline`. The latter was used for the CDF calculation because it makes it easier to integrate over the spline as needed in the CDF calculation. However, `InterpolatedUnivariateSpline` does not take the `kind` parameter, so I think the parameter was just left out. `InterpolatedUnivariateSpline` has an analogous `degree` parameter, which has slightly different behavior from `interp1d`s `kind` parameter. Now both the CDF and PDF use `InterpolatedUnivariateSpline` and `pdf_interpolation_kind` has been renamed to `pdf_interpolation_degree` and takes only integer values like the `degree` parameter of `InterpolatedUnivariateSpline`.
2. The Docstring for `levy_stable_gen` has been revised a little for clarity and some comments have been edited.
3. The change allowing all greek letters to be accepted by the linter has been removed and greek letters have been removed from comments.
4. A test has been added that generates datapoints with `rvs` for different values of `alpha`, `beta`, `gamma`, and `delta` and tests `_fitstart` against these for each of the "S0" and "S1" parametrizations. The goal is to see if fit can recover the original parameters, testing the consistency of  both `fit` and `rvs`. The test fails in all cases. Either `_fitstart` or `rvs` seems to have some remaining issues causing the results to be inaccurate. The test has been marked `xfail`. Perhaps someone should check if there is something wrong with the test. If there's nothing wrong with the test, since the issues with `fit` and `rvs` existed prior to this PR, and because this PR contains many substantial improvements, I think it should still be merged even with this test failing. It can be left for future work to fix things.